### PR TITLE
Improved machine platform detection on linux

### DIFF
--- a/esp.sh
+++ b/esp.sh
@@ -2,8 +2,11 @@
 
 if uname -m | egrep -q 'amd64|x86_64'; then
     espack=./tool/espack64
-else
+elif uname -m | egrep -q 'i386|i686'; then
     espack=./tool/espack32
+else
+    echo Unsupported machine platform: $(uname -m)
+    exit 1
 fi
 
 chmod +x $espack

--- a/esp.sh
+++ b/esp.sh
@@ -2,7 +2,7 @@
 
 if uname -m | egrep -q 'amd64|x86_64'; then
     espack=./tool/espack64
-elif uname -m | egrep -q 'i386|i686'; then
+elif uname -m | egrep -q 'i[3-6]86'; then
     espack=./tool/espack32
 else
     echo Unsupported machine platform: $(uname -m)


### PR DESCRIPTION
`uname -m` can output much more machine platforms like armv8l. Full list is available under this wikipedia link:
https://en.wikipedia.org/wiki/Uname#Examples

Script will throw an error on unsupported platforms