### PR TITLE
use `grep -E` instead of `egrep`

### DIFF
--- a/esp.sh
+++ b/esp.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-if uname -m | egrep -q 'amd64|x86_64'; then
+if uname -m | grep -Eq 'amd64|x86_64'; then
     espack=./tool/espack64
-elif uname -m | egrep -q 'i[3-6]86'; then
+elif uname -m | grep -Eq 'i[3-6]86'; then
     espack=./tool/espack32
 else
     echo Unsupported machine platform: $(uname -m)


### PR DESCRIPTION
egrep has been deprecated in GNU grep since 2007, and >=v3.8 grep emits obsolescence warnings like:

`warning: egrep is obsolescent; using grep -E`